### PR TITLE
replaces imgur link to one for our server

### DIFF
--- a/block_setting_ldl_theme.features.blockexport_settings.inc
+++ b/block_setting_ldl_theme.features.blockexport_settings.inc
@@ -4778,7 +4778,7 @@ function block_setting_ldl_theme_default_blockexport_settings() {
 <p>&nbsp;</p>
 </div>
 
-<div class="footerImg"><img alt="" src="http://i.imgur.com/MuY1yyN.png" />
+<div class="footerImg"><img alt="" src="sites/all/themes/ldl/images/MuY1yyN.png"/>
 <div class="footerTitle">Louisiana&nbsp;Digital&nbsp;Library</div>
 </div>
 ',


### PR DESCRIPTION
Let's pause on pulling in this commit until after the 0.10 rollout, when we can have the meeting Kyle is describing - where we discuss the next changes to make.

What it does:  pulls the louisiana icon at the footer from our production machine, instead of from imgur.  On my dev machine without actual internet latency, it was much faster -- but it could be that imgur can serve this file faster than our production.

I can't say why github decided to delete huge chunks of code & replace it with the same text.  There are only 20 characters changed between the two files -- findable with a search for footerImg.

Also, a real test of this branch will be building a new box.  It passed the simple text of manually updating the GUI "Structure/Blocks/Flex Footer configure/Block body/Source/ with <div class="footerImg"><img alt="" src="sites/all/themes/ldl/images/MuY1yyN.png" /> .  The simple test worked, but a fresh build with this file will prove more.

